### PR TITLE
ci: bump go to 1.24

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -39,7 +39,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.23'
+        go-version: '1.24'
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
Since the project was updated to Go 1.24 we have to update the CI accordingly