### PR TITLE
docs: update 'schedctl start' command to 'schedctl run'

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ sudo systemctl start containerd
 
 ## Usage
 
-Starting and stopping a scheduler using schedctl is trivial. Just identify the scheduler you want to run using `schedctl list` and then operate it using `schedctl start` and `schedctl stop`.
+Starting and stopping a scheduler using schedctl is trivial. Just identify the scheduler you want to run using `schedctl list` and then operate it using `schedctl run` and `schedctl stop`.
 
 Simple as that. The tool will take care of downloading the scheduler and start the binary inside it.
 


### PR DESCRIPTION
```
Available Commands:
  completion  Generate the autocompletion script for the specified shell
  help        Help about any command
  list        list available schedulers
  ps          list running schedulers
  run         Run a specific scheduler
  stop        stop a scheduler
```
The CLI does not provide a start command. 
Update instructions to correctly use schedctl run to initiate a scheduler.